### PR TITLE
Adding null/undefined check in _animateTabTo.

### DIFF
--- a/js/jquery.scrollabletab.js
+++ b/js/jquery.scrollabletab.js
@@ -287,7 +287,9 @@ $.fn.scrollabletabs = function(options)
 			_callBackFnc(o.onTabScroll,e,$tab)
 			
 			//Finally stop the event
-			e.preventDefault();
+			if(e){
+				e.preventDefault();
+			}
 		}
 		
 		function _addCustomerSelToCollection(col,nav)


### PR DESCRIPTION
Fixes TODO 1.
Prevents tabs re-positioning break, when tabs are not in high enough in number when scroll appears.
Need to study code more and proper fix needs to be applied.
